### PR TITLE
Better logic for saving dungeon configuration in localStorage

### DIFF
--- a/lib/dungeon.js
+++ b/lib/dungeon.js
@@ -114,15 +114,11 @@ function save_dungeon_configuration(set_item_key) {
  */
 function new_dungeon() {
     // Saving current dungeon configuration...
-<<<<<<< HEAD
-    save_dungeon_configuration();
-=======
     var dungeon_options_to_save = {};
     $H(dungeon_options).keys().each(function(key_primus) {
         dungeon_options_to_save[key_primus] = $(key_primus).getValue();
     });
     localStorage.setItem('last_saved_query', JSON.stringify(dungeon_options_to_save));
->>>>>>> Implemented local storage saving on new_dungeon().
 
     // Creating new dungeon
     var dungeonOBJ = create_dungeon();

--- a/lib/dungeon.js
+++ b/lib/dungeon.js
@@ -23,6 +23,7 @@ function init_form() {
             $(key_primus).insert(create_option(key_secondus, option_text))
         });
         $(key_primus).observe("change", new_dungeon)
+        $(key_primus).observe("change", save_dungeon_configuration)
     });
     dungeon_options.cer = $("cer").getValue();
     // set defaults
@@ -113,14 +114,6 @@ function save_dungeon_configuration(set_item_key) {
  * Also saves current configuration to localStorage under the key 'last_saved_query'
  */
 function new_dungeon() {
-    // Saving current dungeon configuration...
-    var dungeon_options_to_save = {};
-    $H(dungeon_options).keys().each(function(key_primus) {
-        dungeon_options_to_save[key_primus] = $(key_primus).getValue();
-    });
-    localStorage.setItem('last_saved_query', JSON.stringify(dungeon_options_to_save));
-
-    // Creating new dungeon
     var dungeonOBJ = create_dungeon();
     dungeonOBJ.challenge = 'average';
     image_dungeon_player(dungeonOBJ);

--- a/lib/dungeon.js
+++ b/lib/dungeon.js
@@ -114,7 +114,15 @@ function save_dungeon_configuration(set_item_key) {
  */
 function new_dungeon() {
     // Saving current dungeon configuration...
+<<<<<<< HEAD
     save_dungeon_configuration();
+=======
+    var dungeon_options_to_save = {};
+    $H(dungeon_options).keys().each(function(key_primus) {
+        dungeon_options_to_save[key_primus] = $(key_primus).getValue();
+    });
+    localStorage.setItem('last_saved_query', JSON.stringify(dungeon_options_to_save));
+>>>>>>> Implemented local storage saving on new_dungeon().
 
     // Creating new dungeon
     var dungeonOBJ = create_dungeon();


### PR DESCRIPTION
I wasn't overly happy with the logic I used in #47 (a function calling a function which called...) as it was not obvious when the configuration was saved.

This PR makes it so that the configuration is saved any time any part of the configuration changes (rather than triggering on a `new_dungeon()` call)