### PR TITLE
Fix prand

### DIFF
--- a/lib/prng.js
+++ b/lib/prng.js
@@ -47,7 +47,7 @@ function random(max) {
 *  @returns {number}
  */
 function rand() {
-    return random(1000000000)/1000000000;
+    return random(10000)/10000;
 };
 
 /**


### PR DESCRIPTION
buffer overflow caused all numbers returned by rand_between to be at the low end of the range provided. Fixes #51