### PR TITLE
Fix persistence of configuration options

### DIFF
--- a/lib/dungeon.js
+++ b/lib/dungeon.js
@@ -146,16 +146,12 @@ function cer_reaction() {
  * @param {string} set_item_key - Key to setItem in localStorage. Default: 'last_saved_query'
  */
 function save_dungeon_configuration(set_item_key) {
-    if(typeof(set_item_key) == 'undefined') {
-        set_item_key = 'last_saved_query';
-    }
-
     var dungeon_options_to_save = {};
     $H(dungeon_options).keys().each(function(key_primus) {
         dungeon_options_to_save[key_primus] = $(key_primus).getValue();
     });
 	if (supports_local_storage())
-    	localStorage.setItem(set_item_key, JSON.stringify(dungeon_options_to_save));
+    	localStorage.setItem('last_saved_query', JSON.stringify(dungeon_options_to_save));
 }
 
 /**

--- a/lib/dungeon_types.js
+++ b/lib/dungeon_types.js
@@ -683,8 +683,7 @@ function FetchStorage(key,default_value){
     try {
     	var stored = window.localStorage.getItem(key);
         if (stored) {
-            var tempval = JSON.parse(stored);
-            return tempval[0];
+           return JSON.parse(stored);
         } else {
             UpdateStorage(key, default_value);
             return default_value;

--- a/lib/dungeon_types.js
+++ b/lib/dungeon_types.js
@@ -667,11 +667,10 @@ function dungeon_configuration(seed, style, gridtype, dunlayout, dunsize, stairs
 }
 
 function supports_local_storage() {
-  try {
-    return 'localStorage' in window && window['localStorage'] !== null && localStorage.setItem('test', '1');
-  } catch(e){
-    return false;
-  }
+    return !!window.localStorage
+    && typeof localStorage.getItem === 'function'
+    && typeof localStorage.setItem === 'function'
+    && typeof localStorage.removeItem === 'function';
 }
 
 /**


### PR DESCRIPTION
Configuration options are meant to persist, but this does not work for the following reasons:

1. `supports_local_storage()` in `dungeon_types.js` will never return true. Fixed in 49c9111.
2. `save_dungeon_configuration()` is not called with the correct storage key to actually save the settings. Nowhere in the code actually calls it with *any* specific key, so wiping that out restores the proper behaviour. Fixed in 7f50586.
3. `FetchStorage()` is trying to return the first member of an array from localStorage, but the other localStorage wrappers all deal with objects. Fixed in 6ef13fe.